### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # js-libp2p-nat-mgr
 
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
 [![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-nat-mngr.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-nat-mngr)
 [![](https://img.shields.io/travis/libp2p/js-libp2p-nat-mngr.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-nat-mngr)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-nat-mngr.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-nat-mngr)

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "nat-pmp": "^1.0.0",
     "nat-upnp": "^1.1.1",
     "network": "~0.4.1",
-    "sinon": "^7.2.4"
+    "sinon": "^7.3.1"
   },
   "devDependencies": {
-    "aegir": "^18.1.0",
-    "chai": "^4.1.2",
+    "aegir": "^18.2.2",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   }
 }


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated.